### PR TITLE
fix(commands): hel-cut must delete character after the cursor

### DIFF
--- a/hel-commands.el
+++ b/hel-commands.el
@@ -627,13 +627,13 @@ depending on DIRECTION."
 ;; d
 (hel-define-command hel-cut (count)
   "Kill (cut) text in selection — i.e. delete it and put in the `kill-ring'.
-Without selection delete COUNT characters before point."
+Without selection delete COUNT characters after point."
   :multiple-cursors t
   :merge-selections t
   (interactive "*p")
   (if (use-region-p)
       (kill-region nil nil t)
-    (delete-char (- count)))
+    (delete-char count))
   (hel-extend-selection -1))
 
 ;; D


### PR DESCRIPTION
## Reasons

`hel-cut` and `hel-delete` are very similar. 

The first one delete a character before `point` and put it to the kill-ring.
The second delete a character after `point` and do not put it to the kill-ring.

From my point of view, we do not expect `hel-cut` to delete a character before the `point` for the following reasons:
- Consistency with `hel-delete`
- From an "helix perspective", we expect to delete the character under the box cursor, so after the `point`

## Example

An example with `|` representing my cursor:

```
h|ello
```

It is expected is that `hel-cut` removes `e` and not `h` where `hel-delete` command removes `e`.

Even if the user chose to not follow the package recommandation and choose to change `hel-normal-state-cursor-type` to `'box`, we also expect the letter `e` to be removed (`h|e|llo` for `||` representing the box).

This fix make `hel-cut` and `hel-delete` have the same behavior. The only exception is the first one update the `kill-ring` and the other one not. 

## Suggestions
If we want to delete before `point`, we could create another command or support the minus prefix (`-`) similar to meow to invert the direction.