### PR TITLE
fix: use the correct keymap for input-decode-map "ESC"

### DIFF
--- a/hel-integration.el
+++ b/hel-integration.el
@@ -150,9 +150,10 @@ C-i and RET from C-m."
   (with-selected-frame frame
     (if (eq t (terminal-live-p (frame-terminal frame)))
         ;; Text terminal
-        (progn
+        (let ((original-esc-map (keymap-lookup input-decode-map "ESC")))
+          ;; Use the *original* escape-sequence decoding keymap, not `esc-map'.
           (keymap-set input-decode-map "ESC"
-                      (list 'menu-item "" esc-map :filter #'hel-esc))
+                      (list 'menu-item "" original-esc-map :filter #'hel-esc))
           ;; Kitty keyboard protocol:
           ;; https://sw.kovidgoyal.net/kitty/keyboard-protocol/
           (define-key input-decode-map "\e[105;5u" [C-i])


### PR DESCRIPTION
The error is that the code uses esc-map — a keymap full of commands (like execute-extended-command) — as the fallback binding in input-decode-map.

input-decode-map translates raw input events into other events, not into commands.

When ESC is pressed alone, the filter returns [escape], which is correct.
When another key follows ESC (before the timeout), the filter returns esc-map, and input-decode-map tries to look up that next key in esc-map. The result would be a command, not a Meta‑character event (like M-x). This breaks the normal key lookup because Emacs then tries to process a command as if it were an input event — leading to errors or undefined behaviour. For example, M-f will display "Function returns invalid key sequence: forword-word" in the echo area, M-x will display "KEY must be an integer, cons, symbol, or string" after invoke some commands.

The fix is to replace esc-map with a keymap that translates letters, digits and other common keys into their Meta‑modified character events (e.g., M-x, M-!). The correct map to use is the one that was already in input-decode-map under ESC, the built‑in translation table for terminal escape sequences. 
